### PR TITLE
fix: Resolve TruffleHog BASE/HEAD comparison failure in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,13 +59,39 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Fetch more history for proper commit comparison
+          fetch-depth: 0
+
+      - name: Determine scan range
+        id: scan-range
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # For push events, scan from the previous commit to current commit
+            if [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+              echo "base=${{ github.event.before }}" >> $GITHUB_OUTPUT
+              echo "head=${{ github.sha }}" >> $GITHUB_OUTPUT
+            else
+              # New branch or initial commit - scan just the current commit
+              echo "base=HEAD~1" >> $GITHUB_OUTPUT
+              echo "head=HEAD" >> $GITHUB_OUTPUT
+            fi
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            # For PRs, scan from base branch to PR head
+            echo "base=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+            echo "head=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          else
+            # For scheduled runs, scan the last commit only
+            echo "base=HEAD~1" >> $GITHUB_OUTPUT
+            echo "head=HEAD" >> $GITHUB_OUTPUT
+          fi
 
       - name: Scan for secrets
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: main
-          head: HEAD
+          base: ${{ steps.scan-range.outputs.base }}
+          head: ${{ steps.scan-range.outputs.head }}
           extra_args: --only-verified
 
   # =============================================================================


### PR DESCRIPTION
## Problem Fixed

The Security Scanning workflow was failing on main branch pushes (like after PR merges) with this error:
```
BASE and HEAD commits are the same. TruffleHog won't scan anything.
```

## Root Cause

The TruffleHog action was hardcoded to always compare:
- `base: main` 
- `head: HEAD`

When running on main branch after a push, both resolved to the same commit, causing the failure.

## Solution

Implemented **context-aware commit comparison** that handles different GitHub events appropriately:

### 🔀 **Push Events** (like after PR merge)
- Compare `github.event.before` → `github.sha`
- Scans the actual changes introduced by the push
- Handles edge cases like initial commits

### 📥 **Pull Requests**  
- Compare `base.sha` → `head.sha`
- Scans changes introduced by the PR

### ⏰ **Scheduled Runs**
- Compare `HEAD~1` → `HEAD` 
- Scans the most recent commit

## Changes Made

- **Enhanced checkout**: Added `fetch-depth: 0` for proper git history
- **Dynamic range detection**: Added bash script to determine appropriate base/head commits
- **Edge case handling**: Covers initial commits, new branches, and different event types

## Testing

This fix will be validated by:
1. ✅ **PR workflow**: Should pass security scan (tests the PR logic)
2. ✅ **After merge**: Should pass security scan on main (tests the push logic)  
3. ✅ **Scheduled runs**: Should continue working (tests the schedule logic)

## Files Changed

- `.github/workflows/security.yml`: Enhanced TruffleHog configuration with context-aware logic

## Impact

- 🔧 **Fixes failing security scans** after PR merges
- 🛡️ **Maintains security coverage** for all scenarios  
- 📈 **Improves workflow reliability** across different GitHub events
- ⚠️ **No functional changes** to security scanning behavior

The TruffleHog secrets scanner will now work properly in all contexts while maintaining the same level of security coverage.

🤖 Generated with [Claude Code](https://claude.ai/code)