### PR TITLE
chore: update Docker image to v0.2.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     container_name: service-quality-oracle
 
     # Set the image name
-    image: ghcr.io/graphprotocol/service-quality-oracle:v0.2.1
+    image: ghcr.io/graphprotocol/service-quality-oracle:v0.2.2
 
     volumes:
       # Mount data directory to store data


### PR DESCRIPTION
## Summary
Update docker-compose.yml to use v0.2.2 image which contains the fix for the contract ABI mismatch.

## Context
- PR #24 fixed the contract ABI in main branch
- v0.2.2 will be released via CD workflow with this fix
- This PR updates docker-compose.yml to use the new image version

## Changes
- `docker-compose.yml`: Update image from `v0.2.1` to `v0.2.2`

## Dependencies
This PR should be merged **after** the v0.2.2 release is created through the CD workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)