### PR TITLE
fix: update Dependabot config and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,33 @@
+# CODEOWNERS file for service-quality-oracle
+# This file defines who will be requested for review when someone opens a pull request
+
+# Default owners for everything in the repo
+* @MoonBoi9001
+
+# Python source files
+*.py @MoonBoi9001
+/src/ @MoonBoi9001
+/tests/ @MoonBoi9001
+
+# Configuration files
+*.toml @MoonBoi9001
+*.yml @MoonBoi9001
+*.yaml @MoonBoi9001
+
+# Docker files
+Dockerfile @MoonBoi9001
+docker-compose.yml @MoonBoi9001
+
+# Documentation
+*.md @MoonBoi9001
+/docs/ @MoonBoi9001
+
+# Smart contracts
+/contracts/ @MoonBoi9001
+*.sol @MoonBoi9001
+
+# CI/CD workflows
+/.github/workflows/ @MoonBoi9001
+
+# Kubernetes configurations
+/k8s/ @MoonBoi9001

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 10
-    reviewers:
-      - "MoonBoi9001"
     labels:
       - "dependencies"
       - "docker"
@@ -27,8 +25,6 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 10
-    reviewers:
-      - "MoonBoi9001"
     labels:
       - "dependencies"
       - "python"
@@ -53,8 +49,6 @@ updates:
       time: "09:00" 
       timezone: "UTC"
     open-pull-requests-limit: 10
-    reviewers:
-      - "MoonBoi9001"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## Summary
Fixes issues mentioned in Dependabot PR comments by updating configuration and adding CODEOWNERS file.

## Changes
- ✅ Created missing GitHub labels: `dependencies` and `github-actions`
- 🔧 Removed deprecated `reviewers` field from dependabot.yml 
- 📝 Added CODEOWNERS file to handle PR reviewer assignments

## Context
Dependabot PRs were showing warnings about:
1. Missing labels (now created)
2. Deprecated `reviewers` configuration (now replaced with CODEOWNERS)

## Impact
- Dependabot PRs will now be properly labeled
- PR reviewer assignments will continue working via CODEOWNERS
- Eliminates deprecation warnings in future Dependabot PRs

Fixes issues mentioned in #17, #18, #19, #20, #21, #22, #23

🤖 Generated with [Claude Code](https://claude.ai/code)